### PR TITLE
Issue 6758 - Fix failing webUI tests

### DIFF
--- a/.github/scripts/generate_matrix.py
+++ b/.github/scripts/generate_matrix.py
@@ -21,9 +21,6 @@ else:
     # Use tests from the source
     suites = next(os.walk('dirsrvtests/tests/suites/'))[1]
 
-    # Filter out webui because of broken tests
-    suites.remove('webui')
-
     # Run each replication test module separately to speed things up
     suites.remove('replication')
     repl_tests = glob.glob('dirsrvtests/tests/suites/replication/*_test.py')

--- a/dirsrvtests/tests/suites/webui/__init__.py
+++ b/dirsrvtests/tests/suites/webui/__init__.py
@@ -102,7 +102,7 @@ def setup_login(page):
     page.click("#login-button")
     time.sleep(2)
 
-    if RHEL in distro.linux_distribution():
+    if RHEL in distro.name():
         page.wait_for_selector('text=Red Hat Directory Server')
         page.click('text=Red Hat Directory Server')
     else:
@@ -165,17 +165,17 @@ def create_entry(frame, entry_type, entry_data):
     prepare_page_for_entry(frame, entry_type)
 
     if entry_type == 'User':
-        frame.get_by_role("button", name="Options menu").click()
+        frame.get_by_role("button", name="Basic Account").click()
         frame.get_by_role("option", name="Posix Account").click()
         frame.get_by_role("button", name="Next", exact=True).click()
         frame.get_by_role("button", name="Next", exact=True).click()
 
-        for row, value in enumerate(entry_data.values()):
-            if row > 5:
+        for row, value in enumerate(entry_data.values(), start=1):
+            if row > 6:
                 break
-            frame.get_by_role("button", name=f"Place row {row} in edit mode").click()
+            frame.get_by_role("button", name=f"Edit row {row}").click()
             frame.get_by_role("textbox", name="_").fill(value)
-            frame.get_by_role("button", name=f"Save row edits for row {row}").click()
+            frame.get_by_role("button", name=f"Save edits of row {row}").click()
 
     elif entry_type == 'Group':
         frame.get_by_role("button", name="Next").click()
@@ -184,9 +184,9 @@ def create_entry(frame, entry_type, entry_data):
 
     elif entry_type == 'Organizational Unit':
         frame.get_by_role("button", name="Next", exact=True).click()
-        frame.get_by_role("button", name="Place row 0 in edit mode").click()
+        frame.get_by_role("button", name="Edit row 1").click()
         frame.get_by_role("textbox", name="_").fill(entry_data['ou_name'])
-        frame.get_by_role("button", name="Save row edits for row 0").click()
+        frame.get_by_role("button", name="Save edits of row 1").click()
 
     elif entry_type == 'Role':
         frame.locator("#namingVal").fill(entry_data['role_name'])
@@ -199,12 +199,12 @@ def create_entry(frame, entry_type, entry_data):
         frame.get_by_role("button", name="Next", exact=True).click()
         frame.get_by_role("checkbox", name="Select row 1").check()
         frame.get_by_role("button", name="Next", exact=True).click()
-        frame.get_by_role("button", name="Place row 0 in edit mode").click()
+        frame.get_by_role("button", name="Edit row 1").click()
         frame.get_by_role("textbox", name="_").fill(entry_data['uid'])
-        frame.get_by_role("button", name="Save row edits for row 0").click()
-        frame.get_by_role("button", name="Place row 1 in edit mode").click()
+        frame.get_by_role("button", name="Save edits of row 1").click()
+        frame.get_by_role("button", name="Edit row 2").click()
         frame.get_by_role("textbox", name="_").fill(entry_data['entry_name'])
-        frame.get_by_role("button", name="Save row edits for row 1").click()
+        frame.get_by_role("button", name="Save edits of row 2").click()
 
     finish_entry_creation(frame, entry_type, entry_data)
 

--- a/dirsrvtests/tests/suites/webui/backup/backup_test.py
+++ b/dirsrvtests/tests/suites/webui/backup/backup_test.py
@@ -22,7 +22,6 @@ pytest.importorskip('playwright')
 SERVER_ID = 'standalone1'
 
 
-@pytest.mark.xfail(reason="Will fail because of bz2189181")
 def test_no_backup_dir(topology_st, page, browser_name):
     """ Test that instance is able to load when backup directory doesn't exist.
 

--- a/dirsrvtests/tests/suites/webui/database/database_test.py
+++ b/dirsrvtests/tests/suites/webui/database/database_test.py
@@ -71,7 +71,7 @@ def test_global_database_configuration_availability(topology_st, page, browser_n
     frame = check_frame_assignment(page, browser_name)
     instance = topology_st.standalone
 
-    if instance.get_db_lib() is 'mdb':
+    if instance.get_db_lib() == 'mdb':
         log.info('Check if element on Limits tab is loaded.')
         frame.get_by_role('tab', name='Database', exact=True).click()
 
@@ -90,7 +90,7 @@ def test_global_database_configuration_availability(topology_st, page, browser_n
         log.info('Click on Advanced Settings tab and check if element is loaded')
         frame.get_by_role('tab', name='Advanced Settings', exact=True).click()
         assert frame.locator('#dbhomedir').is_visible()
-    elif instance.get_db_lib() is 'bdb':
+    elif instance.get_db_lib() == 'bdb':
         log.info('Check if element on Limits tab is loaded.')
         frame.get_by_role('tab', name='Database', exact=True).click()
         frame.get_by_text('ID List Scan Limit', exact=True).wait_for()
@@ -291,7 +291,7 @@ def test_suffixes_policy_availability(topology_st, page, browser_name):
 
     log.info('Click on Suffixes and check if element is loaded.')
     frame.get_by_role('tab', name='Database', exact=True).click()
-    frame.locator('#dc\=example\,dc\=com').click()
+    frame.locator(r'#dc\=example\,dc\=com').click()
     frame.locator('#cachememsize').wait_for()
     assert frame.locator('#cachememsize').is_visible()
 
@@ -355,7 +355,7 @@ def test_dictionary_check_checkbox(topology_st, page, browser_name):
     log.info('Disable dictionary check, reload tab and check that Dictionary Check checkbox is unchecked.')
     ppm.set_global_policy({"passworddictcheck": "off"})
     ppm.set_global_policy({"passwordchecksyntax": "on"})
-    frame.get_by_role('img', name="Refresh global password policy settings").click()
+    frame.get_by_role('button', name="Refresh global password policy settings").click()
     assert not frame.get_by_text('Dictionary Check').is_checked()
 
 

--- a/dirsrvtests/tests/suites/webui/ldap_browser/ldap_browser_test.py
+++ b/dirsrvtests/tests/suites/webui/ldap_browser/ldap_browser_test.py
@@ -181,7 +181,6 @@ def test_create_and_delete_group(topology_st, page, browser_name):
     assert frame.get_by_role("button").filter(has_text=f"cn={test_data['group_name']}").count() == 0
 
 
-@pytest.mark.xfail(reason="DS6558")
 def test_create_and_delete_organizational_unit(topology_st, page, browser_name):
     """ Test to create and delete organizational unit
 

--- a/dirsrvtests/tests/suites/webui/login/login_test.py
+++ b/dirsrvtests/tests/suites/webui/login/login_test.py
@@ -65,7 +65,7 @@ def test_login_no_instance(topology_st, page, browser_name):
     page.click('#login-button')
     time.sleep(2)
 
-    if RHEL in distro.linux_distribution():
+    if RHEL in distro.name():
         page.wait_for_selector('text=Red Hat Directory Server')
         assert page.is_visible('text=Red Hat Directory Server')
         log.info('Let us go to RHDS side tab page')

--- a/dirsrvtests/tests/suites/webui/monitoring/monitoring_test.py
+++ b/dirsrvtests/tests/suites/webui/monitoring/monitoring_test.py
@@ -81,11 +81,11 @@ def test_server_statistics_visibility(topology_st, page, browser_name):
 
     log.info('Click on Disk Space tab and check if element is loaded.')
     frame.get_by_role('tab', name='Disk Space').click()
-    assert frame.get_by_role('button', name='Refresh').is_visible()
+    assert frame.get_by_text('Refresh').is_visible()
 
     log.info('Click on SNMP Counters tab and check if element is loaded.')
     frame.get_by_role('tab', name='SNMP Counters').click()
-    assert frame.get_by_text('Bytes Sent', exact=True).is_visible()
+    assert frame.get_by_text('Data Sent', exact=True).is_visible()
 
 
 def test_replication_visibility(topology_st, page, browser_name):
@@ -132,7 +132,6 @@ def test_replication_visibility(topology_st, page, browser_name):
     assert frame.locator('#replication-suffix-dc\\=example\\,dc\\=com').is_visible()
 
 
-@pytest.mark.xfail(reason="DS6557")
 def test_database_visibility(topology_st, page, browser_name):
     """ Test Database monitoring visibility
 
@@ -150,16 +149,26 @@ def test_database_visibility(topology_st, page, browser_name):
     setup_login(page)
     time.sleep(1)
     frame = check_frame_assignment(page, browser_name)
+    instance = topology_st.standalone
 
     log.info('Click on Monitoring tab, then click on database button and check if element is loaded.')
     frame.get_by_role('tab', name='Monitoring', exact=True).click()
+    frame.get_by_label("Monitoring", exact=True).get_by_text("Database").click()
+
+    log.info('Click on Database tab and check if element is loaded.')
+    if instance.get_db_lib() == 'bdb':
+        frame.get_by_role('tab', name='Normalized DN Cache').click()
+
+    frame.get_by_text('NDN Cache Hit Ratio').wait_for()
+    assert frame.get_by_text('NDN Cache Hit Ratio').is_visible()
+
     frame.locator('#dc\\=example\\,dc\\=com').click()
     frame.get_by_text('Entry Cache Hit Ratio').wait_for()
     assert frame.get_by_text('Entry Cache Hit Ratio').is_visible()
 
-    log.info('Click on DN Cache tab and check if element is loaded.')
-    frame.get_by_role('tab', name='DN Cache').click()
-    assert frame.get_by_text('DN Cache Hit Ratio').is_visible()
+    if instance.get_db_lib() == 'bdb':
+        frame.get_by_role('tab', name='DN Cache').click()
+        assert frame.get_by_text('DN Cache Hit Ratio').is_visible()
 
 
 def test_logging_visibility(topology_st, page, browser_name):
@@ -197,28 +206,28 @@ def test_logging_visibility(topology_st, page, browser_name):
     log.info('Click on Monitoring tab, then click on Access Log button and check if element is loaded.')
     frame.get_by_role('tab', name='Monitoring', exact=True).click()
     frame.locator('#access-log-monitor').click()
-    frame.locator('#accesslog-area').wait_for()
-    assert frame.locator('#accesslog-area').is_visible()
+    frame.locator('#monitor-log-access-page').wait_for()
+    assert frame.locator('#monitor-log-access-page').is_visible()
 
     log.info('Click on Audit Log button and check if element is loaded.')
     frame.locator('#audit-log-monitor').click()
-    frame.locator('#auditlog-area').wait_for()
-    assert frame.locator('#auditlog-area').is_visible()
+    frame.locator('#monitor-log-audit-page').wait_for()
+    assert frame.locator('#monitor-log-audit-page').is_visible()
 
     log.info('Click on Audit Failure Log button and check if element is loaded.')
     frame.locator('#auditfail-log-monitor').click()
-    frame.locator('#auditfaillog-area').wait_for()
-    assert frame.locator('#auditfaillog-area').is_visible()
+    frame.locator('#monitor-log-auditfail-page').wait_for()
+    assert frame.locator('#monitor-log-auditfail-page').is_visible()
 
     log.info('Click on Errors Log button and check if element is loaded.')
     frame.locator('#error-log-monitor').click()
-    frame.locator('#errorslog-area').wait_for()
-    assert frame.locator('#errorslog-area').is_visible()
+    frame.locator('#monitor-log-errors-page').wait_for()
+    assert frame.locator('#monitor-log-errors-page').is_visible()
 
     log.info('Click on Security Log button and check if element is loaded.')
     frame.locator('#security-log-monitor').click()
-    frame.locator('#securitylog-area').wait_for()
-    assert frame.locator('#securitylog-area').is_visible()
+    frame.locator('#monitor-log-security-page').wait_for()
+    assert frame.locator('#monitor-log-security-page').is_visible()
 
 
 def test_create_credential_and_alias(topology_st, page, browser_name):

--- a/dirsrvtests/tests/suites/webui/plugins/plugins_test.py
+++ b/dirsrvtests/tests/suites/webui/plugins/plugins_test.py
@@ -230,8 +230,8 @@ def test_memberof_plugin_visibility(topology_st, page, browser_name):
     frame.get_by_role('tab', name='Plugins', exact=True).click()
     frame.get_by_text('Plugin is disabledMemberOf').wait_for()
     frame.get_by_text('Plugin is disabledMemberOf').click()
-    frame.locator('#memberOfConfigEntry').wait_for()
-    assert frame.locator('#memberOfConfigEntry').is_visible()
+    frame.get_by_role('button', name='Create Config').wait_for()
+    assert frame.get_by_role('button', name='Create Config').is_visible()
 
 
 def test_ldap_pass_through_auth_plugin_visibility(topology_st, page, browser_name):


### PR DESCRIPTION
Description:
Fixing webUI tests that are failing due to recent changes. Removing xfail markers where bugs were fixed.
Also includes minor changes in order to remove deprecation warnings. Removing code disabling automatic run of webUI tests.

Relates: #6758

Author: Lenka Doudova

Reviewed by: ???

## Summary by Sourcery

Fix and update WebUI tests to accommodate recent UI label changes, remove deprecation warnings, and re-enable the WebUI suite in CI

Bug Fixes:
- Fix failing WebUI tests by updating selectors and element IDs to match UI changes
- Remove outdated pytest.xfail markers for issues that have been resolved
- Correct Python comparison operators in database library checks from 'is' to '=='

Enhancements:
- Refactor entry creation helper to use updated button names and consistent row indexing
- Replace deprecated distro.linux_distribution() calls with distro.name()
- Update logging visibility tests to assert new monitor page selectors

CI:
- Re-enable WebUI test suite in GitHub Actions matrix by removing its exclusion

Tests:
- Remove code disabling automatic run of WebUI tests
- Adjust database visibility test to handle BDB-specific tabs dynamically